### PR TITLE
Add ability to pass a custom main.js to phantom

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -121,15 +121,11 @@ exports.init = function(grunt) {
     var args = [];
     // Additional options for the PhantomJS main.js script.
     var opts = {};
-    // Main PhantomJS script file.
-    var main = asset('phantomjs/main.js');
 
     // Build args array / opts object.
     Object.keys(options.options).forEach(function(key) {
       if (/^\-\-/.test(key)) {
         args.push(key + '=' + options.options[key]);
-      } else if (key === 'main') {
-        main = options.options[key];
       } else {
         opts[key] = options.options[key];
       }
@@ -138,7 +134,7 @@ exports.init = function(grunt) {
     // Keep -- PhantomJS args first, followed by grunt-specific args.
     args.push(
       // The main PhantomJS script file.
-      main,
+      opts.phantomScript || asset('phantomjs/main.js'),
       // The temporary file used for communications.
       tempfile.path,
       // URL or path to the page .html test file to run.


### PR DESCRIPTION
Pass by setting the 'main' property in the options. I use this for my grunt-mocha task for passing options from the task config to mocha on the client side.
