### PR TITLE
Upgrade phantomjs dependency to 1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eventemitter2": "~0.4.9",
     "semver": "~1.0.14",
     "temporary": "~0.0.4",
-    "phantomjs": "~0.2.6"
+    "phantomjs": "~1.8.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "0.1.0",


### PR DESCRIPTION
To benefit from the latest phantomjs (including the ability to run on CentOS 5.6 and 5.8), this changes the NPM dependency version to 1.8.1.

Working absolutely fine for me.

See discussion in issue #8.
