### PR TITLE
Add useGlobalPhantom task option for environments that can't use phantomjs binaries

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -158,12 +158,20 @@ exports.init = function(grunt) {
       grunt.verbose.or.writeln();
       grunt.log.write('Running PhantomJS...').error();
       if (code === 127) {
-        grunt.log.errorlns(
-          'In order for this task to work properly, PhantomJS must be installed locally via NPM. ' +
-          'If you\'re seeing this message, generally that means the NPM install has failed. ' +
-          'Please submit an issue providing as much detail as possible at: ' +
-          'https://github.com/gruntjs/grunt-lib-phantomjs/issues'
-        );
+        if (options.options.useGlobalPhantom) {
+          grunt.log.errorlns(
+            'In order for this task to work properly, PhantomJS must be ' +
+            'installed and in the system PATH (if you can run "phantomjs" at ' +
+            'the command line, this task should work).'
+          );
+        } else {
+          grunt.log.errorlns(
+            'In order for this task to work properly, PhantomJS must be installed locally via NPM. ' +
+            'If you\'re seeing this message, generally that means the NPM install has failed. ' +
+            'Please submit an issue providing as much detail as possible at: ' +
+            'https://github.com/gruntjs/grunt-lib-phantomjs/issues'
+          );
+        }
         grunt.warn('PhantomJS not found.', failCode);
       } else {
         String(result).split('\n').forEach(grunt.log.error, grunt.log);


### PR DESCRIPTION
The phantomjs package used to install phantom locally only installs a binary for the host system. On systems that can't support phantom binaries ([CentOS <5.8](http://phantomjs.org/download.html#linux) -- unfortunately out of my control), any task that uses `grunt-lib-phantomjs` fails. I've opened an [issue](https://github.com/Obvious/phantomjs/issues/29) with @Obvious to see if there's any hope of having phantom built from source in those cases, but adding a `useGlobalPhantom` task option to `grunt-lib-phantomjs` seems like the easiest path for now.

This commit adds `useGlobalPhantom` as an option available to tasks, which, when set to true, will use the `phantomjs` already in the system path.
