### PR TITLE
Option for rendering a screenshot of the page on failure or timeout

### DIFF
--- a/phantomjs/main.js
+++ b/phantomjs/main.js
@@ -39,9 +39,9 @@ sendMessage('private', 'version', phantom.version);
 setInterval(function() {
   if (new Date() - last > options.timeout) {
     sendMessage('fail.timeout');
-	if (options.screenshot) {
-	  page.render("page-at-timeout.jpg");
-	}
+    if (options.screenshot) {
+      page.render("page-at-timeout.jpg");
+    }
     phantom.exit();
   }
 }, 100);
@@ -125,9 +125,9 @@ page.onLoadFinished = function(status) {
   if (status !== 'success') {
     // File loading failure.
     sendMessage('fail.load', url);
-	if (options.screenshot) {
-	  page.render("page-at-failure.jpg");
-	}
+    if (options.screenshot) {
+      page.render("page-at-failure.jpg");
+    }
     phantom.exit();
   }
 };


### PR DESCRIPTION
Added an option for screenshots of the test page to be rendered upon failure or timeout. Helps with debugging remote test page issues.
