### PR TITLE
Added option to set viewport size on page

### DIFF
--- a/phantomjs/main.js
+++ b/phantomjs/main.js
@@ -127,5 +127,10 @@ page.onLoadFinished = function(status) {
   }
 };
 
+if (options.viewportSize && 
+    (options.viewportSize.width || options.viewportSize.height)) {
+  page.viewportSize = options.viewportSize;
+}
+
 // Actually load url.
 page.open(url);


### PR DESCRIPTION
This change adds an option to set the `viewportSize` option on the Phantomjs `page` object prior to opening the url (`page.open(url);`).

The reason this is necessary is that in many cases Phantomjs does not respect the `window.resizeTo()` method, meaning testing a responsive web site is extremely difficult. The solution is to have a separate test html file (using [grunt-contrib-qunit](https://github.com/gruntjs/grunt-contrib-qunit) in my case) and pass the `viewportSize` option in the task.

Below is an example of how to use this option in conjunction with the `grunt-contrib-qunit` plugin:

```
module.exports = function(grunt) {
    grunt.initConfig({
        pkg: grunt.file.readJSON("package.json"),
        qunit: {
            testLarge: {
                options: {
                    urls: [ "tests/large-format.html" ],
                    viewportSize: { width: 1366, height: 800 }
                }
            },
            testSmall: {
                options: {
                    urls: [ "tests/small-format.html" ],
                    viewportSize: { width: 480, height: 840 }
                }
            }
        }
    });
    grunt.loadNpmTasks("grunt-contrib-qunit");
    grunt.registerTask( "default", [ "qunit" ]);
};
```
