### PR TITLE
Add maxListeners 0 to EventEmmiter2 instantiation to avoid annoying logg...

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -22,7 +22,7 @@ exports.init = function(grunt) {
   var binPath = require('phantomjs').path;
 
   // The module to be exported is an event emitter.
-  var exports = new EventEmitter2({wildcard: true});
+  var exports = new EventEmitter2({wildcard: true, maxListeners: 0});
 
   // Get an asset file, local to the root of the project.
   var asset = path.join.bind(null, __dirname, '..');


### PR DESCRIPTION
...ing

We used grunt-lib-phantomjs upstream with more than 10 listeners due to a huge number of Jasmine tests (split up by listener). We have been patching grunt-lib-phantomjs with this change locally but would like to use master. The default max listeners is 10 in EventEmitter2. If this pull is not acceptable, would a pull with a way of passing a configuration option in to pass down to EventEmitter2 be acceptable?
