### PR TITLE
install error on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eventemitter2": "~0.4.9",
     "semver": "~1.0.14",
     "temporary": "~0.0.4",
-    "phantomjs": "~1.9.0-1"
+    "phantomjs": "1.9.2-1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.2",


### PR DESCRIPTION
Latest version phantomjs package (1.9.2-2) is fail install on Windows.
https://github.com/Obvious/phantomjs/issues/108

Please fixed to version 1.9.2-1.
