### PR TITLE
Kill spawned phantomjs process on cleanup().

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -44,11 +44,26 @@ exports.init = function(grunt) {
     var n = 0;
     // Reset halted flag.
     halted = null;
+    // Handle for spawned process.
+    var phantomJSHandle;
+    // Default options.
+    if (typeof options.killTimeout !== 'number') { options.timeout = 5000; }
 
     // All done? Clean up!
-    var cleanup = function() {
+    var cleanup = function(done, immediate) {
       clearTimeout(id);
       tempfile.unlink();
+      var kill = function(){
+        // Only kill process if it's connected, otherwise an error would be thrown.
+        if (phantomJSHandle.connected){
+          phantomJSHandle.kill();
+        }
+        if (typeof done === 'function') { done(null); }
+      };
+      // Allow immediate killing in an error condition.
+      if (immediate) { return kill(); }
+      // Wait until the timeout expires to kill the process, so it can clean up.
+      setTimeout(kill, options.killTimeout);
     };
 
     // Internal methods.
@@ -104,8 +119,7 @@ exports.init = function(grunt) {
 
       if (done) {
         // All done.
-        cleanup();
-        options.done(null);
+        cleanup(options.done);
       } else {
         // Update n so previously processed lines are ignored.
         n = lines.length;
@@ -146,15 +160,19 @@ exports.init = function(grunt) {
     grunt.log.debug(JSON.stringify(args));
 
     // Actually spawn PhantomJS.
-    return grunt.util.spawn({
+    return phantomJSHandle = grunt.util.spawn({
       cmd: binPath,
       args: args
     }, function(err, result, code) {
       if (!err) { return; }
-      // Something went horribly wrong.
-      cleanup();
+
+      // Ignore intentional cleanup.
+      if (code === 15 /* SIGTERM */){ return; }
+
+      // If we're here, something went horribly wrong.
+      cleanup(null, true /* immediate */);
       grunt.verbose.or.writeln();
-      grunt.log.write('Running PhantomJS...').error();
+      grunt.log.write('PhantomJS threw an error:').error();
       // Print result to stderr because sometimes the 127 code means that a shared library is missing
       String(result).split('\n').forEach(grunt.log.error, grunt.log);
       if (code === 127) {


### PR DESCRIPTION
(Migrated from #45)

When running grunt-contrib-jasmine, which requires this lib, I've had issues with Phantom processes hanging after exit and displaying a "A script on this page appears to have a problem..." dialog.

This PR simply terminates phantom explicitly on cleanup. 
