### PR TITLE
Support Node 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+  - "0.11"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "eventemitter2": "~0.4.9",
     "semver": "~1.0.14",
-    "temporary": "~0.0.4",
+    "temporary": "~0.0.8",
     "phantomjs": "~1.9.0-1"
   },
   "devDependencies": {


### PR DESCRIPTION
Node 0.11 has been failing to run this library due to a bug in the temporary library dependency.  Updating to the latest version to get the fix for https://github.com/vesln/temporary/issues/12 should allow jasmine / phantom testing under 0.11.
