### PR TITLE
Check for a pid rather than connected property of process before killing.

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -55,8 +55,8 @@ exports.init = function(grunt) {
       clearTimeout(id);
       tempfile.unlink();
       var kill = function(){
-        // Only kill process if it's connected, otherwise an error would be thrown.
-        if (phantomJSHandle.connected){
+        // Only kill process if it has a pid, otherwise an error would be thrown.
+        if (phantomJSHandle.pid){
           phantomJSHandle.kill();
         }
         if (typeof done === 'function') { done(null); }


### PR DESCRIPTION
Because the 'connected' property of the spawned phantom process was always false, it was left behind when running tests with grunt-contrib-qunit on Mac OS X10.9.2.  Checking for a pid and not the connected property of the process addressed the problem.  Its possible this might address https://github.com/gruntjs/grunt-contrib-qunit/issues/60. 
