### PR TITLE
Update dependencies to use PhantomJS version 1.9.7-8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-lib-phantomjs",
   "description": "Grunt and PhantomJS, sitting in a tree.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "homepage": "http://github.com/gruntjs/grunt-lib-phantomjs",
   "author": {
     "name": "Grunt Team",
@@ -30,7 +30,7 @@
     "eventemitter2": "~0.4.9",
     "semver": "~1.0.14",
     "temporary": "~0.0.4",
-    "phantomjs": "~1.9.0-1"
+    "phantomjs": "~1.9.7-8"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.2",


### PR DESCRIPTION
This update aims to fix this PhantomJS issue: https://github.com/Medium/phantomjs/issues/161

Mainly, this new version of PhantomJS change to cdnURL from

```
http://cdn.bitbucket.org/ariya/phantomjs/downloads
```

to

```
https://bitbucket.org/ariya/phantomjs/downloads
```

to accordinate with the new Bitbucket URL format.

I also update to package version to 0.6.1 (don't know if it might help, hoping so! :yum: )
