### PR TITLE
Add a handler for phantom.onError

### DIFF
--- a/phantomjs/main.js
+++ b/phantomjs/main.js
@@ -104,6 +104,10 @@ page.onError = function(msg, trace) {
   sendMessage('error.onError', msg, trace);
 };
 
+phantom.onError = function(msg, trace) {
+  sendMessage('error.onError', msg, trace);
+};
+
 // Run before the page is loaded.
 page.onInitialized = function() {
   sendMessage('onInitialized');


### PR DESCRIPTION
As of PhantomJS 1.5, there is a `phantom.onError` handler for catching errors _not_ caught by `page.onError` http://phantomjs.org/api/phantom/handler/on-error.html

I have this sending an event with the same name as used by `page.onError`
