### PR TITLE
lock down phantomjs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eventemitter2": "~0.4.9",
     "semver": "~1.0.14",
     "temporary": "~0.0.4",
-    "phantomjs": "~1.9.0-1"
+    "phantomjs": "1.9.14"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eventemitter2": "~0.4.9",
     "semver": "~1.0.14",
     "temporary": "~0.0.4",
-    "phantomjs": "1.9.14"
+    "phantomjs": "1.9.13"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.2",


### PR DESCRIPTION
[1.9.15 of phantomjs introduced fs-extra](https://github.com/Medium/phantomjs/releases/tag/v1.9.15) which uses `setImmediate` which means no more support for node v0.8. Locking down version here would allow everyone to keep using this module as they are.