### PR TITLE
Bump Phantom dependency to 1.9.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eventemitter2": "~0.4.9",
     "semver": "~1.0.14",
     "temporary": "~0.0.4",
-    "phantomjs": "~1.9.0-1"
+    "phantomjs": "~1.9.15"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.2",


### PR DESCRIPTION
This should address issue #70.

I came across the following error when attempting to run tests with both grunt-contrib-jasmine and grunt-contrib-qunit:

```
Warning: Cannot read property 'connected' of undefined Use --force to continue.
```

Updating  [binPath](https://github.com/gruntjs/grunt-lib-phantomjs/blob/6447bca90cd66a6085215fb89676d263d10586cf/lib/phantomjs.js#L22) to point to my globally installed version of Phantom caused the tests to run. Digging through, it looked like the local version of Phantom wasn't being installed properly, but bumping the version of Phantom to the latest fixes this problem and everything works as expected. :tada: 