### PR TITLE
options.killTimeout has no default value.

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -47,7 +47,7 @@ exports.init = function(grunt) {
     // Handle for spawned process.
     var phantomJSHandle;
     // Default options.
-    if (typeof options.killTimeout !== 'number') { options.timeout = 5000; }
+    if (typeof options.killTimeout !== 'number') { options.killTimeout = 5000; }
     options.options = options.options ||  {};
 
     // All done? Clean up!


### PR DESCRIPTION
I'm fairly certain this line is incorrect:

    if (typeof options.killTimeout !== 'number') { options.timeout = 5000; }

It checks to see if `options.killTimeout` is not a number (most likely it will be undefined), and then sets the `options.timeout` variable. This means that for the setTimeout will still always have an undefined timeout, this results in the setTimeout being executed immediately. Rendering both the "immediate" and the "setTimeout" features here useless.

The only way to actually use the killTimeout option is to explicitly set the option currently.