### PR TITLE
Fix EBUSY error on Windows when deleting temp file

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -50,10 +50,25 @@ exports.init = function(grunt) {
     if (typeof options.killTimeout !== 'number') { options.timeout = 5000; }
     options.options = options.options ||  {};
 
+    var fileCleanup = function(){
+      try {
+        tempfile.unlinkSync();
+      }
+      catch(e) {
+        if(e.code === "EBUSY"){
+          //Windows - OS hasn't released file yet, try again in a bit
+          setTimeout(fileCleanup, 50); 
+        }
+        else{
+            throw e;
+        }
+      }
+    };
+    
     // All done? Clean up!
     var cleanup = function(done, immediate) {
       clearTimeout(id);
-      tempfile.unlink();
+      fileCleanup();
       var kill = function(){
         // Only kill process if it has a pid, otherwise an error would be thrown.
         if (phantomJSHandle.pid){


### PR DESCRIPTION
I'm seeing an error sometimes when I run qunit tests with Grunt on **Windows**. Error message: "Fatal error: EBUSY, resource busy or locked" for the temp file used by PhantomJS.

This pull request has a fix for the issue, basically just retrying the unlink if it fails due to an EBUSY error.