### PR TITLE
Fix EBUSY error on Windows when deleting temp file

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -17,6 +17,7 @@ exports.init = function(grunt) {
   var semver = require('semver');
   var Tempfile = require('temporary').File;
   var EventEmitter2 = require('eventemitter2').EventEmitter2;
+  var rimraf = require('rimraf');
 
   // Get path to phantomjs binary
   var binPath = require('phantomjs-prebuilt').path;
@@ -53,12 +54,14 @@ exports.init = function(grunt) {
     // All done? Clean up!
     var cleanup = function(done, immediate) {
       clearTimeout(id);
-      tempfile.unlink();
       var kill = function(){
         // Only kill process if it has a pid, otherwise an error would be thrown.
         if (phantomJSHandle.pid){
           phantomJSHandle.kill();
         }
+        rimraf(tempfile.path, function(err){
+           if(err) { throw err; }
+        });
         if (typeof done === 'function') { done(null); }
       };
       // Allow immediate killing in an error condition.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "eventemitter2": "^0.4.9",
     "phantomjs-prebuilt": "^2.1.3",
+    "rimraf": "^2.5.2",
     "semver": "^4.3.0",
     "temporary": "^0.0.8"
   },


### PR DESCRIPTION
Closed the previous request, this is an alternative changeset.

This should behave a little more deterministically as the file gets deleted after the process using it is terminated. Additional upside to this is that PhantomJS won't be able to write to the temp file after we delete it.

I was unable to get graceful-fs to work without a similar retry mechanism, though I did see EPERM errors instead of EBUSY. Maybe there's some additional configuration needed that I missed but I couldn't find it.

Possibly the retry timeout should be configurable, but the OS usually unlocks the file almost immediately once the process is terminated. It was working for me even with a setTimout of zero, so the 100 is mostly arbitrary.