### PR TITLE
Fix compatibility with PhantomJS 2.0

### DIFF
--- a/phantomjs/main.js
+++ b/phantomjs/main.js
@@ -11,13 +11,14 @@
 'use strict';
 
 var fs = require('fs');
+var system = require('system');
 
 // The temporary file used for communications.
-var tmpfile = phantom.args[0];
+var tmpfile = system.args[1];
 // The page .html file to load.
-var url = phantom.args[1];
+var url = system.args[2];
 // Extra, optionally overridable stuff.
-var options = JSON.parse(phantom.args[2] || {});
+var options = JSON.parse(system.args[3] || {});
 
 // Default options.
 if (!options.timeout) { options.timeout = 5000; }


### PR DESCRIPTION
PhantomJS 2.0 changed the command-line arguments API. They are now using the `system` library: http://phantomjs.org/api/system/property/args.html

As far as I can tell, it's backwards compatible with 1.9.