### PR TITLE
Unlink temp file only when we are done with it

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -53,13 +53,21 @@ exports.init = function(grunt) {
     // All done? Clean up!
     var cleanup = function(done, immediate) {
       clearTimeout(id);
-      tempfile.unlink();
+
       var kill = function(){
         // Only kill process if it has a pid, otherwise an error would be thrown.
         if (phantomJSHandle.pid){
           phantomJSHandle.kill();
         }
-        if (typeof done === 'function') { done(null); }
+        var unlinkTemp = function() {
+          tempfile.unlink();
+        };
+        if (typeof done === 'function') {
+          done(null);
+          unlinkTemp();
+        } else {
+          unlinkTemp();
+        }
       };
       // Allow immediate killing in an error condition.
       if (immediate) { return kill(); }


### PR DESCRIPTION
Windows doesn't like attempting to unlink a file when it is in use.
This change ensures we only attempt to unlink once we are done. I've tested it on a project that was consistently having the issue and it fixed it.
This change removes the need for a possible infinitely looping setTimeout as suggested in the other pull request for this issue.