### PR TITLE
Rename 'phantomjs' dependency to 'phantomjs-prebuilt'

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -19,7 +19,7 @@ exports.init = function(grunt) {
   var EventEmitter2 = require('eventemitter2').EventEmitter2;
 
   // Get path to phantomjs binary
-  var binPath = require('phantomjs').path;
+  var binPath = require('phantomjs-prebuilt').path;
 
   // The module to be exported is an event emitter.
   var exports = new EventEmitter2({wildcard: true, maxListeners: 0});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "eventemitter2": "^0.4.9",
-    "phantomjs": "^2.1.2",
+    "phantomjs-prebuilt": "^2.1.3",
     "semver": "^4.3.0",
     "temporary": "^0.0.8"
   },


### PR DESCRIPTION
The npm package phantomjs is deprecated. The name was changed to
phantomjs-prebuilt per request of PhantomJS team (Medium/phantomjs#447).

Ref Medium/phantomjs#453
Closes #97