### PR TITLE
Update phantomjs-prebuilt to 2.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "eventemitter2": "^0.4.9",
-    "phantomjs-prebuilt": "^2.1.3",
+    "phantomjs-prebuilt": "^2.1.7",
     "rimraf": "^2.5.2",
     "semver": "^5.1.0",
     "temporary": "^0.0.8"


### PR DESCRIPTION
the 2.1.7 update fixes the rate limit for downloading since they now use the binarys they download form there own GitHub release.