### PR TITLE
Use sync fs.write

### DIFF
--- a/phantomjs/main.js
+++ b/phantomjs/main.js
@@ -30,7 +30,7 @@ var last = new Date();
 var sendMessage = function(arg) {
   var args = Array.isArray(arg) ? arg : [].slice.call(arguments);
   last = new Date();
-  fs.write(tmpfile, JSON.stringify(args) + '\n', 'a');
+  fs.writeSync(tmpfile, JSON.stringify(args) + '\n', 'a');
 };
 
 // This allows grunt to abort if the PhantomJS version isn't adequate.


### PR DESCRIPTION
This makes sure errors will properly propagate to the user instead
of being swallowed.

In the upcoming Node.js 10.x this will also result in an error.
Refs: https://github.com/nodejs/node/pull/18668